### PR TITLE
feat: added support for routing_rules on s3 site

### DIFF
--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -43,6 +43,7 @@ resource "aws_s3_bucket" "website_bucket" {
   website {
     index_document = "index.html"
     error_document = "404.html"
+    routing_rules = "${var.routing_rules}"
   }
 
 //  logging {

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -6,3 +6,6 @@ variable domain {}
 variable duplicate-content-penalty-secret {}
 variable deployer {}
 variable acm-certificate-arn {}
+variable routing_rules {
+  default = ""
+}


### PR DESCRIPTION
Your modules work pretty well, but I needed support for the s3 website's routing rules.

This pull request adds a variable to the site-main module to support passing in routing_rules, with a default empty string, so it won't affect anyone that doesn't need it.

A value can be passed in that matches the terraform aws_s3_bucket.website.routing_rules variable expectations.
