### PR TITLE
Add possibility to customize not-found-error-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ appropriate variables:
        duplicate-content-penalty-secret = "some-secret-password"
        deployer = "an-iam-username"
        acm-certificate-arn = "arn:aws:acm:us-east-1:<id>:certificate/<cert-id>"
+       not-found-response-path = "/404.html"
     }
 
 Mention the double slash. This is to indicate to look into the subdirectory within the Github repository.
@@ -96,6 +97,7 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
 * `acm-certificate-arn`: the id of an certificate in AWS Certificate Manager. As this certificate will be
   used on a CloudFront distribution, Amazon's documentation states the certificate must be generated
   in the `us-east-1` region.
+* `not-found-response-path`: response path for the file that should be served on 404. Default to `/404.html`, but can be e.x. `/index.html` for single page applications.
 
 ### Outputs
 

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -106,7 +106,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
     error_code = "404"
     error_caching_min_ttl = "360"
     response_code = "200"
-    response_page_path = "/404.html"
+    response_page_path = "${var.not-found-response-path}"
   }
   "default_cache_behavior" {
     allowed_methods = ["GET", "HEAD", "DELETE", "OPTIONS", "PATCH", "POST", "PUT"]

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -9,3 +9,6 @@ variable acm-certificate-arn {}
 variable routing_rules {
   default = ""
 }
+variable not-found-response-path {
+  default = "/404.html"
+}


### PR DESCRIPTION
For Single Page Application it's nice to respond with e.x. `index.html` in case of 404. 
