### PR TITLE
Support for `trusted_signers` on CloudFront distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1 (April 26, 2017)
+
+IMPROVEMENTS:
+
+ * Support for `trusted_signers` on the CloudFront distribution of module `site-main`.
+
 ## 3.0.0 (April 19, 2017)
 
 IMPROVEMENTS:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   in the `us-east-1` region.
 * `not-found-response-path`: response path for the file that should be served on 404. Default to `/404.html`,
   but can be e.x. `/index.html` for single page applications.
+* `trusted_signers`: (Optional) List of AWS account IDs that are allowed to create signed URLs for this
+  distribution. May contain `self` to indicate the account where the distribution is created in.
 * `project`: (Optional) the name of a project this site belongs to. Default value = `noproject`
 * `environment`: (Optional) the environment this site belongs to. Default value = `default`
 * `tags`: (Optional) Additional key/value pairs to set as tags.

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -127,6 +127,8 @@ resource "aws_cloudfront_distribution" "website_cdn" {
       }
     }
 
+    trusted_signers = ["${var.trusted_signers}"]
+
     min_ttl          = "0"
     default_ttl      = "300"                                              //3600
     max_ttl          = "1200"                                             //86400

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -32,3 +32,8 @@ variable "tags" {
   description = "Optional Tags"
   default     = {}
 }
+
+variable "trusted_signers" {
+  type = "list"
+  default = []
+}


### PR DESCRIPTION
This is required to allow services to create signed URLs on CloudFront distributions.