### PR TITLE
Add support for redirecting from any subdomain

### DIFF
--- a/site-redirect/main.tf
+++ b/site-redirect/main.tf
@@ -31,14 +31,14 @@ data "template_file" "bucket_policy" {
   template = "${file("${path.module}/website_redirect_bucket_policy.json")}"
 
   vars {
-    bucket = "site.${replace("${var.domain}",".","-")}"
+    bucket = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}"
     secret = "${var.duplicate-content-penalty-secret}"
   }
 }
 
 resource "aws_s3_bucket" "website_bucket" {
   provider = "aws.${var.region}"
-  bucket   = "site.${replace("${var.domain}",".","-")}"
+  bucket   = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}"
   policy   = "${data.template_file.bucket_policy.rendered}"
 
   website {
@@ -50,7 +50,7 @@ resource "aws_s3_bucket" "website_bucket" {
   //    target_prefix = "${var.log_bucket_prefix}"
   //  }
 
-  tags = "${merge("${var.tags}",map("Name", "${var.project}-${var.environment}-${var.domain}", "Environment", "${var.environment}", "Project", "${var.project}"))}"
+  tags = "${merge("${var.tags}",map("Name", "${var.project}-${var.environment}-${replace("${var.domain}","*","star")}", "Environment", "${var.environment}", "Project", "${var.project}"))}"
 }
 
 ################################################################################################################
@@ -60,13 +60,13 @@ data "template_file" "deployer_role_policy_file" {
   template = "${file("${path.module}/deployer_role_policy.json")}"
 
   vars {
-    bucket = "site.${replace("${var.domain}",".","-")}"
+    bucket = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}"
   }
 }
 
 resource "aws_iam_policy" "site_deployer_policy" {
   provider    = "aws.${var.region}"
-  name        = "site.${replace("${var.domain}",".","-")}.deployer"
+  name        = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}.deployer"
   path        = "/"
   description = "Policy allowing to publish a new version of the website to the S3 bucket"
   policy      = "${data.template_file.deployer_role_policy_file.rendered}"
@@ -74,7 +74,7 @@ resource "aws_iam_policy" "site_deployer_policy" {
 
 resource "aws_iam_policy_attachment" "staging-site-deployer-attach-user-policy" {
   provider   = "aws.${var.region}"
-  name       = "site.${replace("${var.domain}",".","-")}-deployer-policy-attachment"
+  name       = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}-deployer-policy-attachment"
   users      = ["${var.deployer}"]
   policy_arn = "${aws_iam_policy.site_deployer_policy.arn}"
 }
@@ -149,6 +149,6 @@ resource "aws_cloudfront_distribution" "website_cdn" {
 
   aliases = ["${var.domain}"]
 
-  tags = "${merge("${var.tags}",map("Name", "${var.project}-${var.environment}-${var.domain}", "Environment", "${var.environment}", "Project", "${var.project}"))}"
+  tags = "${merge("${var.tags}",map("Name", "${var.project}-${var.environment}-${replace("${var.domain}","*","star")}", "Environment", "${var.environment}", "Project", "${var.project}"))}"
 
 }


### PR DESCRIPTION
Cloudfront supports alternate domains w/ wildcards, eg, \*.domain.com, which means the site-redirect module could be used to redirect from any subdomain to the root domain (eg, not just www). However, the '\*' character isn't allowed in tags or bucket names, so it's not possible right out of the box.

This PR makes it possible, w/ the following changes:

* ~Replace both '.' characters & '*' characters w/ '-' in bucket names.~
* ~Replace '*' characters w/ '_' in tags (tried to avoid the double '--' here).~
* ~Don't prefix the bucket name w/ 'site.', since if the domain begins w/ a '*', the bucket name will start w/ 'site.-', and it is not allowed to have a '.' next to a '-' in an s3 bucket name. For some reason, '--' is fine.~
* Replace '*' w/ 'star' in var.domain when used in a name or tag.

~I only made changes to the site-redirect project, and the characters I chose to replace '*' w/ are pretty arbitrary. They work for me, but I don't know if they are the best choices.~