### PR TITLE
Forward query string to origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
 * `project`: (Optional) the name of a project this site belongs to. Default value = `noproject`
 * `environment`: (Optional) the environment this site belongs to. Default value = `default`
 * `tags`: (Optional) Additional key/value pairs to set as tags.
+* `forward-query-string`:  (Optional) Forward the query string to the origin. Default value = `false`
 
 ### Outputs
 

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -120,7 +120,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
     cached_methods  = ["GET", "HEAD"]
 
     "forwarded_values" {
-      query_string = false
+      query_string = "${var.forward-query-string}"
 
       cookies {
         forward = "none"

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -37,3 +37,8 @@ variable "trusted_signers" {
   type = "list"
   default = []
 }
+
+variable "forward-query-string" {
+  description = "Forward the query string to the origin"
+  default     = false
+}


### PR DESCRIPTION
This will make it possible to forward the query string to the origin. Default value stays false and doesn't break any current behaviour.