### PR TITLE
Removed AWS Provider Definition

### DIFF
--- a/site-redirect/main.tf
+++ b/site-redirect/main.tf
@@ -17,14 +17,6 @@
 ################################################################################################################
 
 ################################################################################################################
-## Configure the AWS provider for the specific region
-################################################################################################################
-provider "aws" {
-  alias  = "${var.region}"
-  region = "${var.region}"
-}
-
-################################################################################################################
 ## Configure the bucket and static website hosting
 ################################################################################################################
 data "template_file" "bucket_policy" {
@@ -37,7 +29,6 @@ data "template_file" "bucket_policy" {
 }
 
 resource "aws_s3_bucket" "website_bucket" {
-  provider = "aws.${var.region}"
   bucket   = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}"
   policy   = "${data.template_file.bucket_policy.rendered}"
 
@@ -65,7 +56,6 @@ data "template_file" "deployer_role_policy_file" {
 }
 
 resource "aws_iam_policy" "site_deployer_policy" {
-  provider    = "aws.${var.region}"
   name        = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}.deployer"
   path        = "/"
   description = "Policy allowing to publish a new version of the website to the S3 bucket"
@@ -73,7 +63,6 @@ resource "aws_iam_policy" "site_deployer_policy" {
 }
 
 resource "aws_iam_policy_attachment" "staging-site-deployer-attach-user-policy" {
-  provider   = "aws.${var.region}"
   name       = "site.${replace("${replace("${var.domain}",".","-")}","*","star")}-deployer-policy-attachment"
   users      = ["${var.deployer}"]
   policy_arn = "${aws_iam_policy.site_deployer_policy.arn}"


### PR DESCRIPTION
In all of the other modules, the AWS provider is not initialized and it uses the one defined in the user's terraform file. This module uses the created provider for certain infrastructure but not for others. This causes issues when the user sets the profile on their AWS provider but it is not set here. Because of this provider definition, it has the possibility of deploying infrastructure to two separate AWS accounts.

Evidence: I deployed this module to my work AWS account, but the IAM policy and bucket were created in my personal AWS. The policy was unable to attach also as the IAM user I created was in my work AWS account. 