### PR TITLE
Add optional parameter for custom Default Root Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
 * `acm-certificate-arn`: the id of an certificate in AWS Certificate Manager. As this certificate will be
   used on a CloudFront distribution, Amazon's documentation states the certificate must be generated
   in the `us-east-1` region.
+* `default-root-object`: (Optional) default root object to be served by CloudFront. Defaults to `index.html`, but can be e.x. `v1.0.0/index.html` for versioned applications.
 * `not-found-response-path`: response path for the file that should be served on 404. Default to `/404.html`,
   but can be e.x. `/index.html` for single page applications.
 * `trusted_signers`: (Optional) List of AWS account IDs that are allowed to create signed URLs for this

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -96,7 +96,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
     }
   }
 
-  default_root_object = "index.html"
+  default_root_object = "${var.default-root-object}"
 
   custom_error_response {
     error_code            = "404"

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -23,6 +23,10 @@ variable routing_rules {
   default = ""
 }
 
+variable default-root-object {
+  default = "index.html"
+}
+
 variable not-found-response-path {
   default = "/404.html"
 }


### PR DESCRIPTION
**Problem:**
There is no way to support the website which has multiple versions of SPA in an S3 bucket.

**Solution:**
Allow users to specify a custom Default Root Object of CloudFront Distribution to enable version in users' modules.