### PR TITLE
Allow users to specify an alternative S3 bucket folder to serve from

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   at the point of setting up the DNS part, the CloudFront distribution needs to know for which domain it needs
   to accept requests.
 * `bucket_name`: the name of the bucket to create for the S3 based static website.
+* `bucket_path`: the folder in the S3 bucket to serve the website from. Defaults to `/` which is a root of an S3 bucket.
 * `duplicate-content-penalty-secret`: Value that will be used in a custom header for a CloudFront distribution
   to gain access to the origin S3 bucket. If you make an S3 bucket available as the source for a CloudFront
   distribution, you have the risk of search bots to index both this source bucket and the distribution.

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -82,6 +82,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
   "origin" {
     origin_id   = "origin-bucket-${aws_s3_bucket.website_bucket.id}"
     domain_name = "${aws_s3_bucket.website_bucket.website_endpoint}"
+    origin_path = "${var.bucket_path}"
 
     custom_origin_config {
       origin_protocol_policy = "http-only"

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -14,6 +14,10 @@ variable domain {}
 variable bucket_name {
   description = "The name of the S3 bucket to create."
 }
+variable bucket_path {
+  description = "The folder in the S3 bucket to serve the website from."
+  default = "/"
+}
 
 variable duplicate-content-penalty-secret {}
 variable deployer {}


### PR DESCRIPTION
**Problem:**
The custom `default-root-object` works fine but there are some use cases where you would like to serve a CloudFront distribution from an S3 Folder, not an S3 Bucket Root.

**Solution:**
Use
> origin_path (Optional) - An optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin.

as described in `aws_cloudfront_distribution` Terraform resource to serve the website from a directory, not a S3 Root (still defaults to `/` - S3 Root if not specified).