### PR TITLE
Clean up unused variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   but can be e.x. `/index.html` for single page applications.
 * `trusted_signers`: (Optional) List of AWS account IDs that are allowed to create signed URLs for this
   distribution. May contain `self` to indicate the account where the distribution is created in.
-* `project`: (Optional) the name of a project this site belongs to. Default value = `noproject`
-* `environment`: (Optional) the environment this site belongs to. Default value = `default`
 * `tags`: (Optional) Additional key/value pairs to set as tags.
 * `forward-query-string`:  (Optional) Forward the query string to the origin. Default value = `false`
 * `price_class`: (Optional) The price class that corresponds with the maximum price that you want to pay for CloudFront service.
@@ -128,7 +126,6 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
 
     module "site-redirect" {
        source = "github.com/skyscrapers/terraform-website-s3-cloudfront-route53//site-redirect"
-
        region = "eu-west-1"
        domain = "my.domain.com"
        target = "domain.com"
@@ -139,8 +136,6 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
 
 ### Inputs
 
-* `project`: (Optional) the name of a project this site belongs to. Default value = `noproject`
-* `environment`: (Optional) the environment this site belongs to. Default value = `default`
 * `tags`: (Optional) Additional key/value pairs to set as tags.
 * `default_root_object`: (Optional) The object that you want CloudFront to return (for example, index.html) when an end user requests the root URL. Default value = `index.html`
 * `price_class`: (Optional) The price class that corresponds with the maximum price that you want to pay for CloudFront service.

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -16,6 +16,15 @@
 ##    certificates must be requested in region us-east-1
 ################################################################################################################
 
+locals {
+  tags = merge(
+    var.tags,
+    {
+      "domain" = var.domain
+    },
+  )
+}
+
 ################################################################################################################
 ## Configure the bucket and static website hosting
 ################################################################################################################
@@ -43,14 +52,7 @@ resource "aws_s3_bucket" "website_bucket" {
   //    target_prefix = "${var.log_bucket_prefix}"
   //  }
 
-  tags = merge(
-    var.tags,
-    {
-      "Name"        = "${var.project}-${var.environment}-${var.domain}"
-      "Environment" = var.environment
-      "Project"     = var.project
-    },
-  )
+  tags = locals.tags
 }
 
 ################################################################################################################
@@ -148,14 +150,5 @@ resource "aws_cloudfront_distribution" "website_cdn" {
   }
 
   aliases = [var.domain]
-
-  tags = merge(
-    var.tags,
-    {
-      "Name"        = "${var.project}-${var.environment}-${var.domain}"
-      "Environment" = var.environment
-      "Project"     = var.project
-    },
-  )
+  tags    = locals.tags
 }
-

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -52,7 +52,7 @@ resource "aws_s3_bucket" "website_bucket" {
   //    target_prefix = "${var.log_bucket_prefix}"
   //  }
 
-  tags = locals.tags
+  tags = local.tags
 }
 
 ################################################################################################################
@@ -150,5 +150,5 @@ resource "aws_cloudfront_distribution" "website_cdn" {
   }
 
   aliases = [var.domain]
-  tags    = locals.tags
+  tags    = local.tags
 }

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -2,15 +2,6 @@ variable "region" {
   default = "us-east-1"
 }
 
-variable "project" {
-  default = "noproject"
-}
-
-variable "environment" {
-  type    = string
-  default = "default"
-}
-
 variable "domain" {
   type = string
 }

--- a/site-redirect/main.tf
+++ b/site-redirect/main.tf
@@ -16,6 +16,15 @@
 ##    certificates must be requested in region us-east-1
 ################################################################################################################
 
+locals {
+  tags = merge(
+    var.tags,
+    {
+      "domain" = replace(var.domain, "*", "star")
+    },
+  )
+}
+
 ################################################################################################################
 ## Configure the bucket and static website hosting
 ################################################################################################################
@@ -41,14 +50,7 @@ resource "aws_s3_bucket" "website_bucket" {
   //    target_prefix = "${var.log_bucket_prefix}"
   //  }
 
-  tags = merge(
-    var.tags,
-    {
-      "Name"        = "${var.project}-${var.environment}-${replace(var.domain, "*", "star")}"
-      "Environment" = var.environment
-      "Project"     = var.project
-    },
-  )
+  tags = local.tags
 }
 
 ################################################################################################################
@@ -145,13 +147,5 @@ resource "aws_cloudfront_distribution" "website_cdn" {
 
   aliases = [var.domain]
 
-  tags = merge(
-    var.tags,
-    {
-      "Name"        = "${var.project}-${var.environment}-${replace(var.domain, "*", "star")}"
-      "Environment" = var.environment
-      "Project"     = var.project
-    },
-  )
+  tags = local.tags
 }
-

--- a/site-redirect/variables.tf
+++ b/site-redirect/variables.tf
@@ -3,16 +3,6 @@ variable "region" {
   default = "us-east-1"
 }
 
-variable "project" {
-  type    = string
-  default = "noproject"
-}
-
-variable "environment" {
-  type    = string
-  default = "default"
-}
-
 variable "domain" {
   type = string
 }


### PR DESCRIPTION
The variables "project" and "environment" were only used for tagging.
This limits the module to use a specific set of tags, which might not fit all use cases.
The user can still provide an arbitrary set of tags that fits their needs, via the tags variable.
I've still left the "domain" tag, as it does represent something relevant in the module.

Fixes #28