### PR TITLE
✨ Add variable for minimum TLS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   Read [pricing page](https://aws.amazon.com/cloudfront/pricing/) for more details.
   Options: `PriceClass_100` | `PriceClass_200` | `PriceClass_All`. Default value = `PriceClass_200`
 * `ipv6`:  (Optional) Enable IPv6 support on CloudFront distribution. Default value = `false`
+* `minimum_protocol_version`: (Optional) Set the minimum protocol version of the CloudFront certificate.
+  Read the docs on [Supported Protocols and Ciphers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers)
+  for supported values. Default value = `TLSv1`
 
 ### Outputs
 
@@ -144,6 +147,9 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   Read [pricing page](https://aws.amazon.com/cloudfront/pricing/) for more details.
   Options: `PriceClass_100` | `PriceClass_200` | `PriceClass_All`. Default value = `PriceClass_200`
 * `ipv6`:  (Optional) Enable IPv6 support on CloudFront distribution. Default value = `false`
+* `minimum_protocol_version`: (Optional) Set the minimum protocol version of the CloudFront certificate.
+  Read the docs on [Supported Protocols and Ciphers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers)
+  for supported values. Default value = `TLSv1`
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   Read [pricing page](https://aws.amazon.com/cloudfront/pricing/) for more details.
   Options: `PriceClass_100` | `PriceClass_200` | `PriceClass_All`. Default value = `PriceClass_200`
 * `ipv6`:  (Optional) Enable IPv6 support on CloudFront distribution. Default value = `false`
-* `minimum_protocol_version`: (Optional) Set the minimum protocol version of the CloudFront certificate.
+* `minimum_client_tls_protocol_version`: (Optional) Set the minimum protocol version of the CloudFront certificate.
   Read the docs on [Supported Protocols and Ciphers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers)
   for supported values. Default value = `TLSv1`
 
@@ -147,7 +147,7 @@ See the [Terraform Modules documentation](https://www.terraform.io/docs/modules/
   Read [pricing page](https://aws.amazon.com/cloudfront/pricing/) for more details.
   Options: `PriceClass_100` | `PriceClass_200` | `PriceClass_All`. Default value = `PriceClass_200`
 * `ipv6`:  (Optional) Enable IPv6 support on CloudFront distribution. Default value = `false`
-* `minimum_protocol_version`: (Optional) Set the minimum protocol version of the CloudFront certificate.
+* `minimum_client_tls_protocol_version`: (Optional) Set the minimum protocol version of the CloudFront certificate.
   Read the docs on [Supported Protocols and Ciphers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers)
   for supported values. Default value = `TLSv1`
 

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -147,7 +147,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
   viewer_certificate {
     acm_certificate_arn      = var.acm-certificate-arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
+    minimum_protocol_version = var.minimum_protocol_version
   }
 
   aliases = [var.domain]

--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -147,7 +147,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
   viewer_certificate {
     acm_certificate_arn      = var.acm-certificate-arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = var.minimum_protocol_version
+    minimum_protocol_version = var.minimum_client_tls_protocol_version
   }
 
   aliases = [var.domain]

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -71,3 +71,9 @@ variable "ipv6" {
   description = "Enable IPv6 on CloudFront distribution"
   default     = false
 }
+
+variable "minimum_protocol_version" {
+  type        = string
+  description = "CloudFront viewer certificate minimum protocol version"
+  default     = "TLSv1"
+}

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -72,7 +72,7 @@ variable "ipv6" {
   default     = false
 }
 
-variable "minimum_protocol_version" {
+variable "minimum_client_tls_protocol_version" {
   type        = string
   description = "CloudFront viewer certificate minimum protocol version"
   default     = "TLSv1"

--- a/site-redirect/main.tf
+++ b/site-redirect/main.tf
@@ -143,7 +143,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
   viewer_certificate {
     acm_certificate_arn      = var.acm-certificate-arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = var.minimum_protocol_version
+    minimum_protocol_version = var.minimum_client_tls_protocol_version
   }
 
   aliases = [var.domain]

--- a/site-redirect/main.tf
+++ b/site-redirect/main.tf
@@ -143,7 +143,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
   viewer_certificate {
     acm_certificate_arn      = var.acm-certificate-arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
+    minimum_protocol_version = var.minimum_protocol_version
   }
 
   aliases = [var.domain]

--- a/site-redirect/variables.tf
+++ b/site-redirect/variables.tf
@@ -47,7 +47,7 @@ variable "default_root_object" {
   default     = "index.html"
 }
 
-variable "minimum_protocol_version" {
+variable "minimum_client_tls_protocol_version" {
   type        = string
   description = "CloudFront viewer certificate minimum protocol version"
   default     = "TLSv1"

--- a/site-redirect/variables.tf
+++ b/site-redirect/variables.tf
@@ -46,3 +46,9 @@ variable "default_root_object" {
   description = "CloudFront default root object"
   default     = "index.html"
 }
+
+variable "minimum_protocol_version" {
+  type        = string
+  description = "CloudFront viewer certificate minimum protocol version"
+  default     = "TLSv1"
+}


### PR DESCRIPTION
We wanted to be able to set a minimum protocol version so that the [SSL Tester](https://www.ssllabs.com/ssltest/) would give us an A (as well as fulfilling company compliance requirements), so the minimum protocol version is now a variable with the same default as before. Existing users shouldn't see a change, but running this in TF for us with a custom value does correctly replace the value in-place.