### PR TITLE
FIX: Wildcard domain cannot be given due to AWS tag rule violation

### DIFF
--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -20,7 +20,7 @@ locals {
   tags = merge(
     var.tags,
     {
-      "domain" = var.domain
+      "domain" = replace(var.domain, "*", "--wildcard--")
     },
   )
 }


### PR DESCRIPTION
Module would be able to handle wildcard domains but AWS tag rules block terraform apply.
I have added a placeholder instead of '*'. Please feel free to suggest a better one or modify it on your own.