### PR TITLE
Support list of alternate cnames for cloudfront

### DIFF
--- a/site-main/main.tf
+++ b/site-main/main.tf
@@ -155,6 +155,6 @@ resource "aws_cloudfront_distribution" "website_cdn" {
     minimum_protocol_version = var.minimum_client_tls_protocol_version
   }
 
-  aliases = [var.domain]
+  aliases = concat([var.domain],var.aliases)
   tags    = local.tags
 }

--- a/site-main/variables.tf
+++ b/site-main/variables.tf
@@ -84,3 +84,9 @@ variable "force_destroy" {
   description = "A boolean that indicates all objects (including any locked objects) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
   default = false
 }
+
+variable "aliases" {
+  type    = list(string)
+  description = "A list of alternate cnames"
+  default = []
+}

--- a/site-redirect/main.tf
+++ b/site-redirect/main.tf
@@ -150,7 +150,7 @@ resource "aws_cloudfront_distribution" "website_cdn" {
     minimum_protocol_version = var.minimum_client_tls_protocol_version
   }
 
-  aliases = [var.domain]
+  aliases = concat([var.domain],var.aliases)
 
   tags = local.tags
 }

--- a/site-redirect/main.tf
+++ b/site-redirect/main.tf
@@ -53,6 +53,14 @@ resource "aws_s3_bucket" "website_bucket" {
   tags = local.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "website_bucket" {
+  bucket                  = aws_s3_bucket.website_bucket
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
+}
+
 ################################################################################################################
 ## Configure the credentials and access to the bucket for a deployment user
 ################################################################################################################

--- a/site-redirect/variables.tf
+++ b/site-redirect/variables.tf
@@ -53,3 +53,9 @@ variable "minimum_client_tls_protocol_version" {
   description = "CloudFront viewer certificate minimum protocol version"
   default     = "TLSv1"
 }
+
+variable "aliases" {
+  type    = list(string)
+  description = "A list of alternate cnames"
+  default = []
+}

--- a/site-redirect/variables.tf
+++ b/site-redirect/variables.tf
@@ -59,3 +59,20 @@ variable "aliases" {
   description = "A list of alternate cnames"
   default = []
 }
+
+# s3 public access block settings
+variable  "block_public_acls" {
+  type = bool
+}  
+
+variable  "block_public_policy" {
+  type = bool
+}   
+
+variable  "ignore_public_acls" {
+  type = bool
+}   
+
+variable  "restrict_public_buckets" {
+  type = bool
+}   


### PR DESCRIPTION
Allows you to provide a list of alternate domains, .e.g when you link both a domain.com and www.domain.com